### PR TITLE
Feature/optional status led SK6812 (WS2812B)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ A common ground between the ESP32 and the LED is required.
 | Valid spool/tag | Filament color |
 | Blank/invalid tag | Red flash |
 | Tag removed | Off |
-| Write success | Green flash then restore filament color |
-| Write failure | Red flash then restore filament color/off |
+| Write success | Green flash, then firmware restores filament color |
+| Write failure | Red flash, then firmware restores filament color or turns LED off |
 
 ### Enabling the LED
 

--- a/README.md
+++ b/README.md
@@ -30,12 +30,69 @@ Validated by the model author with a Prusa MK4S + MMU3 setup using PrusaLink. Th
 
 # Hardware Setup
 
+
 ## Hardware Needed
 *   NFC Reader/Writer: PN5180 NFC module (ISO 15693)
 *   LCD Screen: [16x2 I2C LCD](https://a.co/d/dryhwvd) (only 1 needed)
 *   ESP32: [ESP32 DevKitC V4](https://a.co/d/gW3zBIJ) (only 1 needed)
 *   USB Cable: USB-A to USB-C (1)
 *   Jumper wires: male-to-female Dupont wires (9)
+*   Optional Status LED: SK6812 RGBW (WS2812-compatible addressable LED, 1 pixel)
+
+## Optional Status LED
+
+The scanner firmware now supports an optional single‑pixel addressable status LED. This LED provides visual feedback for scanner state and spool/tag events.
+
+**Recommended LED:**
+
+* SK6812 RGBW (WS2812‑compatible addressable LED)
+
+The firmware is configured for **SK6812 RGBW timing and color order** using:
+
+`NEO_GRBW + NEO_KHZ800`
+
+### Wiring
+
+Default LED data pin:
+
+`GPIO4`
+
+> **Note:** A single SK6812 RGBW LED module is recommended. Many small breakout boards include the necessary capacitor and resistor already. If using a bare LED, a ~330Ω resistor on the data line is recommended for signal stability.
+
+Typical wiring for a single LED:
+
+| LED Pin | ESP32 Pin |
+|-------|-----------|
+| VCC | 5V |
+| GND | GND |
+| DIN | GPIO4 |
+
+A common ground between the ESP32 and the LED is required.
+
+### LED Status States
+
+| Event | LED Behavior |
+|------|--------------|
+| Booting | White |
+| WiFi connected | Cyan |
+| Ready | Blue |
+| Tag detected | Yellow flash |
+| Valid spool/tag | Filament color |
+| Blank/invalid tag | Red flash |
+| Tag removed | Off |
+| Write success | Green flash then restore filament color |
+| Write failure | Red flash then restore filament color/off |
+
+### Enabling the LED
+
+The LED feature is optional and controlled via the build configuration in `platformio.ini`:
+
+```
+build_flags =
+    -DUSE_STATUS_LED=1
+```
+
+If `USE_STATUS_LED` is not enabled, the firmware behaves exactly as before and the LED code is not compiled.
 
 ### Printables BOM (non-printed parts)
 The model page lists this BOM:

--- a/README.md
+++ b/README.md
@@ -85,14 +85,40 @@ A common ground between the ESP32 and the LED is required.
 
 ### Enabling the LED
 
-The LED feature is optional and controlled via the build configuration in `platformio.ini`:
+The status LED feature is **optional** and is controlled via the build configuration in `platformio.ini`.
+
+To enable the LED, add the following build flags:
 
 ```
 build_flags =
     -DUSE_STATUS_LED=1
+    -DSTATUS_LED_PIN=4
 ```
 
-If `USE_STATUS_LED` is not enabled, the firmware behaves exactly as before and the LED code is not compiled.
+**Explanation:**
+
+* `USE_STATUS_LED` enables compilation of the LED feature.
+* `STATUS_LED_PIN` sets the ESP32 GPIO pin used for the LED data line.
+
+You may change the pin to any suitable GPIO supported by your ESP32 board. For example:
+
+```
+build_flags =
+    -DUSE_STATUS_LED=1
+    -DSTATUS_LED_PIN=16
+```
+
+### Disabling the LED
+
+If you do **not** have the optional status LED installed, simply omit the `USE_STATUS_LED` flag from `platformio.ini`.
+
+Example with LED disabled:
+
+```
+build_flags =
+```
+
+When the flag is not present, the LED code is **not compiled**, and the firmware behaves exactly like the original scanner firmware with no LED functionality.
 
 ### Printables BOM (non-printed parts)
 The model page lists this BOM:

--- a/platformio.ini
+++ b/platformio.ini
@@ -21,6 +21,7 @@ build_flags =
 	-DCONFIG_BTDM_CTRL_MODE_BLE_ONLY=1
 	-DCONFIG_BT_BLE_ENABLED=1
 	-DUSE_STATUS_LED=1
+	-DSTATUS_LED_PIN=4
 lib_deps = 
 	marcoschwartz/LiquidCrystal_I2C@^1.1.4
 	bblanchon/ArduinoJson@^7.0.0

--- a/platformio.ini
+++ b/platformio.ini
@@ -20,9 +20,11 @@ build_flags =
 	-DCONFIG_BT_ENABLED=1
 	-DCONFIG_BTDM_CTRL_MODE_BLE_ONLY=1
 	-DCONFIG_BT_BLE_ENABLED=1
+	-DUSE_STATUS_LED=1
 lib_deps = 
 	marcoschwartz/LiquidCrystal_I2C@^1.1.4
 	bblanchon/ArduinoJson@^7.0.0
 	densaugeo/base64@^1.4.0
 	knolleary/PubSubClient@^2.8
 	codewitch-honey-crisis/htcw_json@^0.2.5
+	adafruit/Adafruit NeoPixel

--- a/src/ApplicationManager.cpp
+++ b/src/ApplicationManager.cpp
@@ -9,6 +9,10 @@
   #include "ConfigurationManager.h"
   #include "HomeAssistantManager.h"
   #include <Arduino.h>
+  #if USE_STATUS_LED
+  #include "LEDManager.h"
+  extern LEDManager ledManager;
+  #endif
   #include <WiFi.h>
 #else
   #include "platform/NativePlatform.h"
@@ -252,6 +256,15 @@ void ApplicationManager::handleSpoolDetected(const AppMessage& msg) {
         msg.payload.spoolDetected.spool_id,
         msg.payload.spoolDetected.material_type,
         msg.payload.spoolDetected.kg_remaining);
+    
+    #if USE_STATUS_LED
+        ledManager.flashTagDetected();
+        ledManager.showFilamentColor(
+            msg.payload.spoolDetected.primary_color[0],
+            msg.payload.spoolDetected.primary_color[1],
+            msg.payload.spoolDetected.primary_color[2]
+        );
+    #endif
 
     if (currentState == AppState::MONITORING_PRINT) {
         if (startingSpoolId[0] == '\0') {
@@ -340,6 +353,25 @@ void ApplicationManager::handleSpoolUpdated(const AppMessage& msg) {
     bool spoolmanConfigured = false;
 #endif
 
+#if USE_STATUS_LED
+    if (msg.payload.spoolUpdated.success) {
+        ledManager.flashWriteSuccess();
+    } else {
+        ledManager.flashWriteFailure();
+    }
+
+    if (state.tag_data_valid) {
+        uint8_t color[4] = {0};
+        if (opt_get_primary_color(&state.tag_data, color) == OPT_OK) {
+            ledManager.showFilamentColor(color[0], color[1], color[2]);
+        } else {
+            ledManager.showOff();
+        }
+    } else {
+        ledManager.showOff();
+    }
+#endif
+
     if (lcdManager) {
         if (msg.payload.spoolUpdated.success) {
             char line1[17];
@@ -422,6 +454,9 @@ void ApplicationManager::handleSpoolUpdated(const AppMessage& msg) {
 void ApplicationManager::handleBlankTagDetected(const AppMessage& msg) {
     Serial.printf("EVENT: BlankTagDetected - spool_id=%s\n",
         msg.payload.blankTag.spool_id);
+#if USE_STATUS_LED
+    ledManager.flashParseFailed();
+#endif
 
     pendingStatusAfterTagRemoved = false;
 
@@ -564,6 +599,9 @@ void ApplicationManager::handleSpoolmanSynced(const AppMessage& msg) {
 void ApplicationManager::handleTagRemoved(const AppMessage& msg) {
     Serial.printf("EVENT: TagRemoved - spool_id=%s\n",
         msg.payload.tagRemoved.spool_id);
+#if USE_STATUS_LED
+    ledManager.showOff();
+#endif
 
     // Clear displayed spool so next scan re-displays
     lastDisplayedSpoolId[0] = '\0';

--- a/src/LEDManager.cpp
+++ b/src/LEDManager.cpp
@@ -3,10 +3,9 @@
 #include <cstdlib>
 
 LEDManager::LEDManager()
-    : _initialized(false), _pixel(1, 0, NEO_GRB + NEO_KHZ800) {}
-
+    : _initialized(false), _pixel(1, 0, NEO_GRBW + NEO_KHZ800) {}
 void LEDManager::begin(uint8_t pin) {
-    _pixel.updateType(NEO_GRB + NEO_KHZ800);
+    _pixel.updateType(NEO_GRBW + NEO_KHZ800);    
     _pixel.setPin(pin);
     _pixel.begin();
     _pixel.setBrightness(64);
@@ -16,7 +15,7 @@ void LEDManager::begin(uint8_t pin) {
 
 void LEDManager::setColor(uint8_t r, uint8_t g, uint8_t b) {
     if (!_initialized) return;
-    _pixel.setPixelColor(0, _pixel.Color(r, g, b));
+    _pixel.setPixelColor(0, _pixel.Color(r, g, b, 0));
     _pixel.show();
 }
 
@@ -25,7 +24,9 @@ void LEDManager::showOff() {
 }
 
 void LEDManager::showBooting() {
-    setColor(255, 255, 255);
+    if (!_initialized) return;
+    _pixel.setPixelColor(0, _pixel.Color(0, 0, 0, 255));  // pure white via W channel
+    _pixel.show();
 }
 
 void LEDManager::showWifiConnected() {

--- a/src/LEDManager.cpp
+++ b/src/LEDManager.cpp
@@ -1,0 +1,91 @@
+#include "LEDManager.h"
+
+#include <cstdlib>
+
+LEDManager::LEDManager()
+    : _initialized(false), _pixel(1, 0, NEO_GRB + NEO_KHZ800) {}
+
+void LEDManager::begin(uint8_t pin) {
+    _pixel.updateType(NEO_GRB + NEO_KHZ800);
+    _pixel.setPin(pin);
+    _pixel.begin();
+    _pixel.setBrightness(64);
+    _pixel.show();  // clear
+    _initialized = true;
+}
+
+void LEDManager::setColor(uint8_t r, uint8_t g, uint8_t b) {
+    if (!_initialized) return;
+    _pixel.setPixelColor(0, _pixel.Color(r, g, b));
+    _pixel.show();
+}
+
+void LEDManager::showOff() {
+    setColor(0, 0, 0);
+}
+
+void LEDManager::showBooting() {
+    setColor(255, 255, 255);
+}
+
+void LEDManager::showWifiConnected() {
+    setColor(0, 255, 255);  // cyan
+}
+
+void LEDManager::showWifiFailed() {
+    setColor(255, 0, 0);
+}
+
+void LEDManager::showReady() {
+    setColor(0, 0, 255);  // blue
+}
+
+void LEDManager::flashTagDetected() {
+    if (!_initialized) return;
+    setColor(255, 255, 0);  // yellow
+    delay(100);
+    showOff();
+}
+
+void LEDManager::flashParseFailed() {
+    if (!_initialized) return;
+    setColor(255, 0, 0);  // red
+    delay(100);
+    showOff();
+}
+
+void LEDManager::flashWriteSuccess() {
+    if (!_initialized) return;
+    setColor(0, 255, 0);  // green
+    delay(100);
+}
+
+void LEDManager::flashWriteFailure() {
+    if (!_initialized) return;
+    setColor(255, 0, 0);  // red
+    delay(100);
+}
+
+void LEDManager::showFilamentColor(uint8_t r, uint8_t g, uint8_t b) {
+    setColor(r, g, b);
+}
+
+void LEDManager::setFilamentColorFromHex(const char* hex) {
+    if (!_initialized || !hex) return;
+
+    if (hex[0] == '#') {
+        hex++;
+    }
+
+    char* endptr = nullptr;
+    unsigned long color = strtoul(hex, &endptr, 16);
+    if (endptr == hex) {
+        return;
+    }
+
+    uint8_t r = (color >> 16) & 0xFF;
+    uint8_t g = (color >> 8) & 0xFF;
+    uint8_t b = color & 0xFF;
+
+    showFilamentColor(r, g, b);
+}

--- a/src/LEDManager.h
+++ b/src/LEDManager.h
@@ -1,0 +1,33 @@
+#ifndef LED_MANAGER_H
+#define LED_MANAGER_H
+
+#include <Adafruit_NeoPixel.h>
+
+class LEDManager {
+public:
+    LEDManager();
+
+    void begin(uint8_t pin);
+
+    void showOff();
+    void showBooting();
+    void showWifiConnected();
+    void showWifiFailed();
+    void showReady();
+
+    void flashTagDetected();
+    void flashParseFailed();
+    void flashWriteSuccess();
+    void flashWriteFailure();
+
+    void showFilamentColor(uint8_t r, uint8_t g, uint8_t b);
+    void setFilamentColorFromHex(const char* hex);
+
+private:
+    bool _initialized;
+    Adafruit_NeoPixel _pixel;
+
+    void setColor(uint8_t r, uint8_t g, uint8_t b);
+};
+
+#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,7 +13,6 @@
 #include "StubPrinterLinkStrategy.h"
 #include "LCDManager.h"
 
-#define STATUS_LED_PIN 4
 
 #if USE_STATUS_LED
 #include "LEDManager.h"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,6 +13,13 @@
 #include "StubPrinterLinkStrategy.h"
 #include "LCDManager.h"
 
+#define STATUS_LED_PIN 4
+
+#if USE_STATUS_LED
+#include "LEDManager.h"
+LEDManager ledManager;
+#endif
+
 // Global HTTP mutex for serializing WiFi HTTP requests
 SemaphoreHandle_t g_httpMutex = nullptr;
 
@@ -54,15 +61,18 @@ void initWiFi() {
 
     lcdManager.updateScreen("WiFi OK", WiFi.localIP().toString().c_str());
 
+#if USE_STATUS_LED
+    ledManager.showWifiConnected();  // network up — not yet fully initialized
+#endif
+
     Serial.println("Setting up NTP...");
     configTime(0, 0, "pool.ntp.org");
     struct tm timeinfo;
-    if(!getLocalTime(&timeinfo)){
+    if (!getLocalTime(&timeinfo)) {
       Serial.println("Failed to obtain time");
       lcdManager.updateScreen("NTP FAILED", "");
     } else {
       Serial.println("Time obtained");
-      //lcdManager.updateScreen("NTP OK", "");
     }
 
     delay(2000);
@@ -71,6 +81,11 @@ void initWiFi() {
     Serial.println("WiFi connection failed!");
 
     lcdManager.updateScreen("WiFi FAILED", "");
+
+#if USE_STATUS_LED
+    ledManager.showWifiFailed();
+#endif
+
     delay(2000);
   }
 }
@@ -80,6 +95,11 @@ void setup() {
   Serial.begin(9600);
   delay(1000);
   Serial.println("=== Starting setup ===");
+
+#if USE_STATUS_LED
+  ledManager.begin(STATUS_LED_PIN);
+  ledManager.showBooting();
+#endif
 
   // Initialize I2C with custom pins for LCD
   Wire.begin(LCD_SDA, LCD_SCL);
@@ -105,7 +125,6 @@ void setup() {
     lcdManager.updateScreen("AppMgr FAILED", "");
     while (1) { delay(1000); }
   }
-
 
   // Initialize BluetoothManager BEFORE WiFi (they share the radio)
   lcdManager.updateScreen("Starting BLE...", "");
@@ -149,9 +168,7 @@ void setup() {
     while (1) { delay(1000); }
   }
 
-  // Initialize and start PrinterManager with stub strategy for testing
-  // To use real PrusaLink API, replace StubPrinterLinkStrategy with PrusaLinkAPIStrategy
-  //static StubPrinterLinkStrategy printerStrategy;
+  // Initialize and start PrinterManager
   static PrusaLinkAPIStrategy printerStrategy;
   printerStrategy.setHttpMutex(g_httpMutex);
   PrinterManager::getInstance().setStrategy(&printerStrategy);
@@ -168,10 +185,8 @@ void setup() {
   // Start SpoolmanManager task
   SpoolmanManager::getInstance().startTask();
 
-  // Build status + HA startup from same config snapshot
-  auto& config = ConfigurationManager::getInstance();
-
   // Start HomeAssistantManager task
+  auto& config = ConfigurationManager::getInstance();
   Serial.printf("Setup: HA config before startTask: enabled=%s host='%s' host_len=%u port=%u user_set=%s\n",
                 config.getHAEnabled() ? "true" : "false",
                 config.getHAMqttHost(),
@@ -181,6 +196,10 @@ void setup() {
   HomeAssistantManager::getInstance().startTask();
 
   ApplicationManager::getInstance().showStatusOnLCD();
+
+#if USE_STATUS_LED
+  ledManager.showReady();  // NFC + Spoolman + HA + scanner all initialized
+#endif
 
   Serial.println("=== Setup complete ===");
 }


### PR DESCRIPTION
## Summary

This PR adds optional support for a single-pixel **SK6812 RGBW status LED** to `openprinttag_scanner`.

The LED provides quick visual feedback for scanner state changes such as:

- boot / initialization
- WiFi connected or failed
- scanner ready
- tag detected
- valid spool/tag color
- blank or invalid tag
- tag removed
- write success / failure

The feature is **fully optional** and controlled via `platformio.ini` build flags.

---

## Why Add a Status LED?

A small addressable LED provides quick visual feedback without needing to look at the LCD or serial console.

Examples include:

- boot / initialization status  
- WiFi connected or failed  
- scanner ready  
- tag detected  
- write success or failure  

The LED can also briefly display the **filament color** stored on the tag, providing a quick visual confirmation when a spool is scanned.

I also wanted this feature for my **SpoolSense** project (work in progress):  
https://github.com/sjordan0228/SpoolSense

In that setup the LED provides immediate feedback that a spool scan was recognized or that a tag write/update occurred, similar to what I am already doing with **ESP32 + PN532 scanners**.

I plan to point SpoolSense users to this project as the recommended scanner firmware for supporting the **OpenPrintTag standard**.

---

## Implementation

### Added

- `src/LEDManager.h`
- `src/LEDManager.cpp`

These implement a small LED controller responsible for displaying scanner status.

### Updated

- `src/main.cpp`
- `src/ApplicationManager.cpp`
- `platformio.ini`
- `README.md`

LED updates are triggered by scanner events (boot, WiFi status, tag events, write results, etc.).

---

## LED Behavior

| Event | LED Behavior |
|------|--------------|
| Booting | White |
| WiFi connected | Cyan |
| WiFi failed | Red |
| Scanner ready | Blue |
| Tag detected | Yellow flash |
| Valid spool/tag | Filament color |
| Blank/invalid tag | Red flash |
| Tag removed | Off |
| Write success | Green flash, then firmware restores filament color |
| Write failure | Red flash, then firmware restores filament color or turns LED off |

State restoration after write operations is handled by the firmware logic rather than internally within `LEDManager`.

---

## Configuration

The LED feature is controlled via `platformio.ini`.

### Enable LED

```
build_flags =
    -DUSE_STATUS_LED=1
    -DSTATUS_LED_PIN=4
```

### Explanation

- `USE_STATUS_LED` enables compilation of the LED feature
- `STATUS_LED_PIN` sets the ESP32 GPIO pin used for the LED data line

Example using a different pin:

```
build_flags =
    -DUSE_STATUS_LED=1
    -DSTATUS_LED_PIN=16
```

### Disable LED

If the LED is not installed, simply omit the flag:

```
build_flags =
```

When `USE_STATUS_LED` is not present the LED code is **not compiled**, and the firmware behaves exactly like the original scanner firmware.

---

## Hardware Notes

Recommended LED:

- **SK6812 RGBW** (WS2812-compatible addressable LED)

Current implementation uses:

```
NEO_GRBW + NEO_KHZ800
```

A **~330Ω resistor** on the data line is recommended.

---

## Testing Status

This has been compile-tested but not yet validated on physical hardware. I am waiting on hardware to complete testing.

Feedback on LED behavior, brightness, and W-channel white on real SK6812 modules is welcome.